### PR TITLE
fix Issue #499 get_field_info model is None

### DIFF
--- a/imagekit/models/fields/files.py
+++ b/imagekit/models/fields/files.py
@@ -7,6 +7,7 @@ from ...utils import generate, suggest_extension
 
 class ProcessedImageFieldFile(ImageFieldFile):
     def save(self, name, content, save=True):
+        content.instance = self.instance
         filename, ext = os.path.splitext(name)
         spec = self.field.get_spec(source=content)
         ext = suggest_extension(name, spec.format)


### PR DESCRIPTION
get_field_info in utils.py uses field_file and tries to get getattr(field_file, 'instance', None)
but instance field doesn't even exist in the object
so may be we should put the instance here, in save method